### PR TITLE
改行コード周りのエラーの修正

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,11 +9,12 @@
     "plugin:import/warnings",
     "eslint:recommended"
   ],
-  "plugins": ["prettier", "@typescript-eslint"],
+  "plugins": ["@typescript-eslint"],
   "rules": {
     "prettier/prettier": [
       "error",
       {
+        "tabWidth": 2,
         "semi": true
       }
     ],

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,1 @@
-{
-  "tabWidth": 2,
-  "semi": true
-}
+{}


### PR DESCRIPTION
## 🔨 変更内容

- Prettier の設定周りの軽微な修正

## ⚠改行コード周りの話⚠

- Vercel でデプロイする時に、改行コードが「CRLF」だと落ちた (原因不明)
  - これが解消できれば、`.eslintrc.json` に `endOfLine: "crlf"` を追加すれば、CRLF で扱える
- 今回はVercel でデプロイできることを優先するため、VSCode 上で「LF」に指定することで Prettier のエラーを回避しながら開発をする

## 💡 確認事項

- VSCode の右下の改行コードを「LF」にしたら、改行コード周りのエラーが解消されていること

## ✅ 解決するイシュー

- close #8

## 🤝 関連するイシュー

- #8
