### PR TITLE
import 周りのルールの変更

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,29 +25,28 @@
       "error",
       {
         "groups": [
-          "builtin",
-          "external",
-          "internal",
-          ["sibling", "parent"],
-          "object"
-        ],
-        "pathGroups": [
-          {
-            "pattern": "react",
-            "group": "builtin",
-            "position": "before"
-          },
-          {
-            "pattern": ".*/src/components/**",
-            "group": "internal",
-            "position": "before"
-          }
+          "builtin", // 組み込みモジュール
+          "external", // yarn add したパッケージ
+          "internal" // 自作モジュール
         ],
         "newlines-between": "always",
         "alphabetize": {
           "order": "asc",
           "caseInsensitive": true
-        }
+        },
+        "pathGroupsExcludedImportTypes": ["react", "next", "next/**"],
+        "pathGroups": [
+          {
+            "pattern": "@chakra-ui/react",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "@/components/**",
+            "group": "internal",
+            "position": "before"
+          }
+        ]
       }
     ],
     "no-console": "warn",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
-import { ChakraProvider } from "@chakra-ui/react";
 import type { AppProps } from "next/app";
 import React from "react";
+
+import { ChakraProvider } from "@chakra-ui/react";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/components/TempComponent.tsx
+++ b/src/components/TempComponent.tsx
@@ -1,5 +1,6 @@
-import { Card, CardBody, Text } from "@chakra-ui/react";
 import React from "react";
+
+import { Card, CardBody, Text } from "@chakra-ui/react";
 
 export const TempComponent = () => {
   return (


### PR DESCRIPTION
## 🔨 変更内容

- import 順のルールを変更した
  - 変更後のルール
    - 「react, next 周り」「chakra-ui」「自作のコンポーネント」の順
- `settings.json` に `yarn lint --fix` が自動で走る機構を追加した

## 📢 この PR に含まないこと
- import 周り以外のルールに関すること

## 📸 スクリーンショット

## ✅ 解決するイシュー

- close #5

## 🤝 関連するイシュー

- #5
