### PR TITLE
SemanticPR の設定のカスタマイズ

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,13 @@
+# The values allowed for the "type" part of the PR title/commit message. e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"
+types: # default: feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - chore
+  - ci
+  - Merge
+  - merge


### PR DESCRIPTION
## 🔨 変更内容

- SemanticPR の CI の prefix に `Merge` を追加
  - デフォルトに merge しないと反映されないらしい ([公式ドキュメント](https://github.com/Ezard/semantic-prs#configuration)より)

## 📢 この PR に含まないこと

## 📸 スクリーンショット

## ✅ 解決するイシュー

- close #16

## 🤝 関連するイシュー

- #16
